### PR TITLE
Fix int range overflow for mid calculation in binary search algorithm

### DIFF
--- a/Searching_Algorithm/BinarySearch_UsingRecursion.java
+++ b/Searching_Algorithm/BinarySearch_UsingRecursion.java
@@ -5,7 +5,7 @@ public class BinarySearch_UsingRecursion{
 		if(si>ei){
 			return -1;
 		}
-		int mid=(si+ei)/2;
+		int mid = si + (ei - si) / 2;
 		if(arr[mid]==num){
 			return mid;
 		}

--- a/Searching_Algorithm/Binary_Search.java
+++ b/Searching_Algorithm/Binary_Search.java
@@ -4,7 +4,7 @@ public class Binary_Search {
         int Start=0;
         int End=arr.length-1;
         while(Start<=End){
-            int mid=(Start+End)/2;
+            int mid = Start + (End - Start) / 2;
         if(arr[mid]==element){
             return mid;
         }


### PR DESCRIPTION
When we calculate the mid value as "int mid = (low + high) / 2", there can be an error due to the overflow of integer range. In this case if the low index is a non - zero value and the high index is suppose at "Integer.MAX_VALUE", the sum value will be greater than the integer range. To fix this issue we can calculate the mid value as "int mid = low + (high - low) / 2". In this case the overflow situation will not be there due to the subtraction operation.